### PR TITLE
optional parameters, added % on uptime, refactor

### DIFF
--- a/checkapi.sh
+++ b/checkapi.sh
@@ -5,40 +5,52 @@ YEL='\033[1;33m'
 GRE='\033[1;32m'
 NC='\033[0m' # No Color
 
+if [ -z "$1" ]
+then
+	server=127.0.0.1
+else
+	server=$1
+fi
 
-port=$2
-server=$1
-
-echo "The server is $server and the port is $port"
-
-printf " \n"
-echo "*********************************************************************************"
-
+if [ -z "$2" ]
+then
+	port=14002
+else
+	port=$2
+fi
 
 readarray -t sats < <( curl -s $server:$port/api/dashboard | jq .data.satellites | jq -r '.[]')
 
+echo "Scores are based on recent node performance, all time stats are provided for reference only"
+
+printf " \n"
+
 for n in "${sats[@]}"
 do
-  echo -e "${GRE}Satellite: ${NC}${YEL}$n${NC}"
+	echo -e "${GRE}Satellite: ${NC}${YEL}$n${NC}"
 
-  success=$(curl -s $server:$port/api/satellite/$n | jq .data.audit.successCount)
+	success=$(curl -s $server:$port/api/satellite/$n | jq .data.audit.successCount)
 	total=$(curl -s $server:$port/api/satellite/$n | jq .data.audit.totalCount)
 	score=$(curl -s $server:$port/api/satellite/$n | jq .data.audit.score)
 
-  if [ $total -gt '0' ]
+	if [ $total -gt '0' ]
 	then
 		audrate=$(awk "BEGIN { pc=100*${success}/${total}; i=int(pc); print (pc-i<0.5)?i:i+1 }")
-		echo -e "${GRE}Audits:${NC} $success/$total >> ${RED}$audrate%${NC} --- Overall Score: ${RED}$score${NC}"
+		echo -e "${GRE}Audits:${NC} Current score: ${RED}$score${NC} (all time stats: $success/$total >> $audrate%)"
 	else
-		echo -e "${GRE}Audits:${NC} No audits from ths satellite!"
+		echo -e "${GRE}Audits:${NC} No audits from this satellite!"
 	fi
 
 	success=$(curl -s $server:$port/api/satellite/$n | jq .data.uptime.successCount)
-  total=$(curl -s $server:$port/api/satellite/$n | jq .data.uptime.totalCount)
+	total=$(curl -s $server:$port/api/satellite/$n | jq .data.uptime.totalCount)
 	score=$(curl -s $server:$port/api/satellite/$n | jq .data.uptime.score)
 
-	echo -e "${GRE}Uptime:${NC} $success/$total --- Overall Score: ${RED}$score${NC}"
-	printf " \n"
-	echo "*********************************************************************************"
+	if [ $total -gt '0' ]
+	then
+		uprate=$(awk "BEGIN { pc=100*${success}/${total}; i=int(pc); print (pc-i<0.5)?i:i+1 }")
+		echo -e "${GRE}Uptime:${NC} Current score: ${RED}$score${NC} (all time stats: $success/$total >> $uprate%)"
+	else
+		echo -e "${GRE}Uptime:${NC} No uptime checks from this satellite!"
+	fi
 	printf " \n"
 done


### PR DESCRIPTION
Parameters are now optional and default to 127.0.0.1 and 14002, since that's what most SNO's will use.
I added uptime % and checked whether total uptime checks <> 0
Refactored output to make it more clear that scores are about recent performance and all time stats are just there for reference.